### PR TITLE
카카오 소셜 로그인 완료 PR 요청 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'com.h2database:h2'
+
 
 	// JWT Library
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/com/crewManager/pro/auth/controller/AuthController.java
+++ b/src/main/java/com/crewManager/pro/auth/controller/AuthController.java
@@ -44,7 +44,7 @@ public class AuthController {
         ResponseCookie deleteCookie = ResponseCookie.from("accessToken", "") // 쿠키 값을 비웁니다.
                 .path("/")
                 .httpOnly(true)
-                .secure(true)
+                .secure(false)// https 에서는 true , http 에서는 false로 해야함.
                 .maxAge(0) // 만료 시간을 0으로 설정하여 즉시 삭제되도록 합니다.
                 .build();
 

--- a/src/main/java/com/crewManager/pro/auth/controller/AuthController.java
+++ b/src/main/java/com/crewManager/pro/auth/controller/AuthController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -34,5 +35,25 @@ public class AuthController {
         return new ResponseEntity<>(jwtToken,headers, HttpStatus.OK);
     }
 
+    // [새로 추가] 로그아웃 메소드
+    @PostMapping("/logout")
+    public ResponseEntity<String> logout() {
+        log.info("로그아웃 요청 처리 시작");
+
+        // 쿠키를 삭제하기 위해 만료 시간을 0으로 설정한 쿠키를 생성합니다.
+        ResponseCookie deleteCookie = ResponseCookie.from("accessToken", "") // 쿠키 값을 비웁니다.
+                .path("/")
+                .httpOnly(true)
+                .secure(true)
+                .maxAge(0) // 만료 시간을 0으로 설정하여 즉시 삭제되도록 합니다.
+                .build();
+
+        log.info("로그아웃 쿠키 생성 완료. 클라이언트로 전송합니다.");
+
+        // Set-Cookie 헤더에 삭제할 쿠키를 담아 응답합니다.
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, deleteCookie.toString())
+                .body("로그아웃 되었습니다.");
+    }
 
 }

--- a/src/main/java/com/crewManager/pro/auth/dto/OAuthLoginRequestDto.java
+++ b/src/main/java/com/crewManager/pro/auth/dto/OAuthLoginRequestDto.java
@@ -3,6 +3,7 @@ package com.crewManager.pro.auth.dto;
 
 import com.crewManager.pro.crew.domain.CrewMemberRole;
 import com.crewManager.pro.auth.SocialType;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 import net.minidev.json.annotate.JsonIgnore;
@@ -14,15 +15,16 @@ public class OAuthLoginRequestDto {
     @JsonIgnore
     private SocialType socialType;
 
+    @NotBlank
     private String authorizationCode;
 
-    @JsonIgnore
+
     private String name;
-    @JsonIgnore
+
     private String phoneNumber;
-    @JsonIgnore
+
     private CrewMemberRole crewMemberRole;
-    @JsonIgnore
+
     private String crewName;
 
 }

--- a/src/main/java/com/crewManager/pro/auth/dto/OAuthLoginRequestDto.java
+++ b/src/main/java/com/crewManager/pro/auth/dto/OAuthLoginRequestDto.java
@@ -16,12 +16,13 @@ public class OAuthLoginRequestDto {
 
     private String authorizationCode;
 
+    @JsonIgnore
     private String name;
-
+    @JsonIgnore
     private String phoneNumber;
-
+    @JsonIgnore
     private CrewMemberRole crewMemberRole;
-
+    @JsonIgnore
     private String crewName;
 
 }

--- a/src/main/java/com/crewManager/pro/auth/service/AuthService.java
+++ b/src/main/java/com/crewManager/pro/auth/service/AuthService.java
@@ -60,13 +60,19 @@ public class AuthService {
      */
     @Transactional
     public User processUserAndCrewRegistration(OAuthUserProfile userProfile, OAuthLoginRequestDto req) {
-        // UserService를 통해 사용자를 찾거나 새로 생성합니다.
-        User user = userService.findOrCreateUser(userProfile.getEmail(), req.getName());
-
-        // CrewService를 통해 크루 멤버십 관련 로직을 처리합니다.
-        crewService.registerCrewMember(user, req.getCrewName(), req.getCrewMemberRole());
-
-        return user;
+        // 회원가입 플로우: 프론트에서 이름, 크루 정보 등을 넘겨준 경우
+        if (req.getName() != null && !req.getName().isBlank()) {
+            log.info("회원가입 플로우를 진행합니다. Email: {}", userProfile.getEmail());
+            User user = userService.createUser(userProfile.getEmail(), req);
+            crewService.registerCrewMember(user, req.getCrewName(), req.getCrewMemberRole());
+            return user;
+        }
+        // 로그인 플로우: 추가 정보가 없는 경우 (기존 유저)
+        else {
+            log.info("로그인 플로우를 진행합니다. Email: {}", userProfile.getEmail());
+            // 이메일로 사용자를 찾기만 하고, 없으면 예외를 발생시킵니다.
+            return userService.findUserByEmail(userProfile.getEmail());
+        }
     }
 
     /**

--- a/src/main/java/com/crewManager/pro/config/security/SecurityConfig.java
+++ b/src/main/java/com/crewManager/pro/config/security/SecurityConfig.java
@@ -60,6 +60,7 @@ public class SecurityConfig {
                     // 로그인/회원가입은 인증 없이 허용 나머진 인증 적용.
                     authorize.requestMatchers("/api/**").permitAll()
                             .anyRequest().authenticated();
+
                 })
                 .cors(cors -> cors.configurationSource(corsConfigurationSource())) // 프론트와 연결하기 위한 cors 정책 적용.
                 // 기본 UsernamePassword 적용 전 커스텀 filter 먼저 확인.

--- a/src/main/java/com/crewManager/pro/config/security/SecurityConfig.java
+++ b/src/main/java/com/crewManager/pro/config/security/SecurityConfig.java
@@ -56,10 +56,10 @@ public class SecurityConfig {
                 })
                 // 토큰 인증 규칙
                 .authorizeHttpRequests(authorize-> {
+                    authorize.requestMatchers("/api/auth/**", "/api/crew/all").permitAll(); // 로그인, 크루 목록은 허용
+                    authorize.requestMatchers("/api/users/me", "/api/crew/my/**").authenticated(); // 내 정보, 내 크루 정보 등은 인증 필요
                     authorize.requestMatchers("/admin/**").hasRole(String.valueOf(AppRole.ADMIN));
-                    // 로그인/회원가입은 인증 없이 허용 나머진 인증 적용.
-                    authorize.requestMatchers("/api/**").permitAll()
-                            .anyRequest().authenticated();
+                    authorize.anyRequest().denyAll(); // 명시되지 않은 모든 요청은 거부 (White-list 방식)
 
                 })
                 .cors(cors -> cors.configurationSource(corsConfigurationSource())) // 프론트와 연결하기 위한 cors 정책 적용.

--- a/src/main/java/com/crewManager/pro/crew/service/CrewService.java
+++ b/src/main/java/com/crewManager/pro/crew/service/CrewService.java
@@ -36,14 +36,13 @@ public class CrewService {
     @Transactional
     public void registerCrewMember(User user, String crewName, CrewMemberRole role) {
         if (crewName == null || crewName.isBlank()) {
-            log.info("Crew registration skipped for user: {}", user.getEmail());
-            return;
+            throw new BusinessException(ErrorCode.CREW_NOT_FOUND);
         }
 
         if (role == null) {
             // 역할이 지정되지 않은 경우, 아무 작업도 하지 않고 종료
             log.info("User {} has no role specified for crew registration. Skipping.", user.getEmail());
-            return;
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
         if (CrewMemberRole.CREW_LEADER == role) {

--- a/src/main/java/com/crewManager/pro/crew/service/CrewService.java
+++ b/src/main/java/com/crewManager/pro/crew/service/CrewService.java
@@ -35,6 +35,11 @@ public class CrewService {
      */
     @Transactional
     public void registerCrewMember(User user, String crewName, CrewMemberRole role) {
+        if (crewName == null || crewName.isBlank()) {
+            log.info("Crew registration skipped for user: {}", user.getEmail());
+            return;
+        }
+
         if (role == null) {
             // 역할이 지정되지 않은 경우, 아무 작업도 하지 않고 종료
             log.info("User {} has no role specified for crew registration. Skipping.", user.getEmail());

--- a/src/main/java/com/crewManager/pro/exception/ErrorCode.java
+++ b/src/main/java/com/crewManager/pro/exception/ErrorCode.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     CREW_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 크루를 찾을 수 없습니다."),
-    CREW_MEMBER_DUPLICATED(HttpStatus.CONFLICT, "이미 존재하는 멤버 입니다."),
+    CREW_MEMBER_DUPLICATED(HttpStatus.CONFLICT, "이미 가입한 멤버 입니다."),
     CREW_NAME_DUPLICATED(HttpStatus.CONFLICT, "이미 존재하는 크루 이름입니다."),
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다.");
 

--- a/src/main/java/com/crewManager/pro/exception/ErrorCode.java
+++ b/src/main/java/com/crewManager/pro/exception/ErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
-
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원을 찾을 수 없습니다."),
     CREW_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 크루를 찾을 수 없습니다."),
     CREW_MEMBER_DUPLICATED(HttpStatus.CONFLICT, "이미 가입한 멤버 입니다."),
     CREW_NAME_DUPLICATED(HttpStatus.CONFLICT, "이미 존재하는 크루 이름입니다."),

--- a/src/main/java/com/crewManager/pro/user/controller/UserController.java
+++ b/src/main/java/com/crewManager/pro/user/controller/UserController.java
@@ -1,0 +1,35 @@
+package com.crewManager.pro.user.controller;
+
+import com.crewManager.pro.user.domain.User;
+import com.crewManager.pro.user.dto.response.UserResponse;
+import com.crewManager.pro.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+
+
+    @GetMapping("/me")
+    public ResponseEntity<UserResponse> getMyInfo(Authentication authentication) {
+        if (authentication == null || authentication.getName() == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        String  userId = authentication.getName(); // Long 타입 ID 사용
+        User user = userService.findById(userId);
+
+        // 기존 DTO 변환 메서드를 그대로 사용
+        return ResponseEntity.ok(UserResponse.fromEntity(user));
+    }
+}

--- a/src/main/java/com/crewManager/pro/user/dto/response/UserResponse.java
+++ b/src/main/java/com/crewManager/pro/user/dto/response/UserResponse.java
@@ -1,5 +1,6 @@
 package com.crewManager.pro.user.dto.response;
 
+import com.crewManager.pro.user.AppRole;
 import com.crewManager.pro.user.domain.User;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,6 +12,8 @@ public class UserResponse {
     private String id;          // 사용자의 고유 ID (UUID)
     private String name;        // 사용자 이름
     private String phoneNumber; // 사용자 전화번호
+    private String email;      // 이메일 정보 추가
+    private AppRole role;      // 역할 정보 추가 (문자열 대신 Enum 타입 그대로 사용 가능)
     private LocalDateTime createdAt; // 생성 시간
     private LocalDateTime updatedAt; // 업데이트 시간
 
@@ -20,6 +23,8 @@ public class UserResponse {
                 .id(user.getId())
                 .name(user.getName())
                 .phoneNumber(user.getPhoneNumber())
+                .email(user.getEmail())         // [수정] 이메일 매핑 추가
+                .role(user.getAppRole())        // [수정] 역할 매핑 추가
                 .createdAt(user.getCreatedAt())
                 .updatedAt(user.getUpdatedAt())
                 .build();

--- a/src/main/java/com/crewManager/pro/user/service/UserService.java
+++ b/src/main/java/com/crewManager/pro/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.crewManager.pro.user.service;
 
+import com.crewManager.pro.user.AppRole;
 import com.crewManager.pro.user.domain.User;
 import com.crewManager.pro.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -36,7 +37,7 @@ public class UserService {
                             .email(email)
                             .name(name)
                             .password(passwordEncoder.encode(UUID.randomUUID().toString()))
-                            // .appRole(UserRole.USER) // 기본 역할 설정이 필요하다면 여기에 추가
+                            .appRole(AppRole.GENERAL)
                             .build();
                     return userRepository.save(newUser);
                 });

--- a/src/main/java/com/crewManager/pro/user/service/UserService.java
+++ b/src/main/java/com/crewManager/pro/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.crewManager.pro.user.service;
 import com.crewManager.pro.user.AppRole;
 import com.crewManager.pro.user.domain.User;
 import com.crewManager.pro.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -14,7 +15,7 @@ import java.util.UUID;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional(readOnly = true) // 클래스 레벨에서는 기본적으로 읽기 전용 트랜잭션
 public class UserService {
 
     private final UserRepository userRepository;
@@ -28,18 +29,38 @@ public class UserService {
      * @param name 사용자 이름 (신규 가입 시 사용)
      * @return 찾거나 새로 생성한 User 객체
      */
-    @Transactional
+    @Transactional // 쓰기 작업이므로 개별적으로 @Transactional 어노테이션을 붙여 readOnly=false를 적용
     public User findOrCreateUser(String email, String name) {
         return userRepository.findByEmail(email)
                 .orElseGet(() -> {
-                    log.info("New user registration: {}", email);
+                    log.info("새로운 사용자 등록을 시작합니다. Email: {}", email);
                     User newUser = User.builder()
+                            .id(UUID.randomUUID().toString()) // UUID를 직접 생성하여 설정
                             .email(email)
                             .name(name)
+                            // 소셜 로그인이므로 실제 비밀번호는 의미가 없습니다. 임의의 값으로 설정합니다.
                             .password(passwordEncoder.encode(UUID.randomUUID().toString()))
-                            .appRole(AppRole.GENERAL)
+                            .appRole(AppRole.GENERAL) // 기본 역할 설정
                             .build();
                     return userRepository.save(newUser);
                 });
     }
+
+    /**
+     * [새로 추가] 사용자 ID를 기반으로 사용자를 찾아서 반환합니다.
+     * 사용자가 존재하지 않을 경우 EntityNotFoundException 예외를 발생시킵니다.
+     * @param userId 찾을 사용자의 ID
+     * @return 찾아낸 User 객체
+     * @throws EntityNotFoundException 사용자를 찾지 못한 경우
+     */
+    public User findById(String userId) { // ID 타입이 Long이라면 Long으로 받습니다.
+        log.debug("ID로 사용자 조회를 시도합니다. User ID: {}", userId);
+        return userRepository.findById(userId)
+                .orElseThrow(() -> {
+                    log.error("사용자를 찾을 수 없습니다. User ID: {}", userId);
+                    return new EntityNotFoundException("ID가 " + userId + "인 사용자를 찾을 수 없습니다.");
+                });
+    }
+
+
 }

--- a/src/main/java/com/crewManager/pro/user/service/UserService.java
+++ b/src/main/java/com/crewManager/pro/user/service/UserService.java
@@ -1,5 +1,7 @@
 package com.crewManager.pro.user.service;
 
+import com.crewManager.pro.exception.BusinessException;
+import com.crewManager.pro.exception.ErrorCode;
 import com.crewManager.pro.user.AppRole;
 import com.crewManager.pro.user.domain.User;
 import com.crewManager.pro.user.repository.UserRepository;
@@ -34,6 +36,7 @@ public class UserService {
         return userRepository.findByEmail(email)
                 .orElseGet(() -> {
                     log.info("새로운 사용자 등록을 시작합니다. Email: {}", email);
+                    if(name== null){throw new BusinessException(ErrorCode.MEMBER_NOT_FOUND);}
                     User newUser = User.builder()
                             .id(UUID.randomUUID().toString()) // UUID를 직접 생성하여 설정
                             .email(email)

--- a/src/main/java/com/crewManager/pro/user/service/UserService.java
+++ b/src/main/java/com/crewManager/pro/user/service/UserService.java
@@ -28,21 +28,21 @@ public class UserService {
     @Transactional
     public User createUser(String email, OAuthLoginRequestDto req) {
         // 중복 가입 방지 체크 (중요!)
-        if (userRepository.findByEmail(email).isPresent()) {
-            // 이 경우는 비정상적인 접근일 수 있습니다.
-            throw new BusinessException(ErrorCode.MEMBER_NOT_FOUND);
-        }
-        if(req.getName() == null || req.getName().isBlank()){
-            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
-        }
-        User newUser = User.builder()
-                .email(email)
-                .name(req.getName())
-                .phoneNumber(req.getPhoneNumber())
-//                .password(passwordEncoder.encode(UUID.randomUUID().toString()))
-                .appRole(AppRole.GENERAL)
-                .build();
-        return userRepository.save(newUser);
+        return userRepository.findByEmail(email)
+                .orElseGet(()->{
+                    if(req.getName() == null || req.getName().isBlank()){
+                        throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+                    }
+                    User newUser = User.builder()
+                            .email(email)
+                            .name(req.getName())
+                            .phoneNumber(req.getPhoneNumber())
+                            .appRole(AppRole.GENERAL)
+                            .build();
+                    return userRepository.save(newUser);
+                });
+
+
     }
 
     // [신규] 사용자 '조회' 전용 메소드

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,17 +1,17 @@
 spring:
-#  datasource:
-#    url: jdbc:mysql://localhost:3306/crew_db?serverTimezone=UTC
-#    username : developer
-#    password : password
   datasource:
-    url: jdbc:h2:mem:testdb
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
+    url: jdbc:mysql://localhost:3306/crew_db?serverTimezone=UTC
+    username : developer
+    password : password
+#  datasource:
+#    url: jdbc:h2:mem:testdb
+#    driver-class-name: org.h2.Driver
+#    username: sa
+#    password:
+#  h2:
+#    console:
+#      enabled: true
+#      path: /h2-console
   jpa:
     show-sql: true
     hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,17 @@
 spring:
+#  datasource:
+#    url: jdbc:mysql://localhost:3306/crew_db?serverTimezone=UTC
+#    username : developer
+#    password : password
   datasource:
-    url: jdbc:mysql://localhost:3306/crew_db?serverTimezone=UTC
-    username : developer
-    password : password
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
   jpa:
     show-sql: true
     hibernate:


### PR DESCRIPTION
feature/kakao 에서 develop으로 merg 된 내용 main push 요청 .

카카오 소셜 로그인 기능 완료

/api/auth/login/[provider] api 적용 완료
- 인터페이스 를 활용하여 provider 접근후 , 다른 소셜 로그인에 대한 접근성 확보 

/api/auth/login
- 해당 api를 통해서 jwt token 생성 및 로그인/회원가입 판단후 JPA 엔터티에 적용.

/api/auth/logout
- 쿠키방식의 accesstoken 값 제거 httpOnly 

/api/users/me
- 회원가입진행시 크루 선택에 필요 ( 등록된 전체 크루 조회)




